### PR TITLE
Fix execution error with node.js v4

### DIFF
--- a/modules/mysensors/gateway.js
+++ b/modules/mysensors/gateway.js
@@ -19,10 +19,6 @@ var GATEWAY_ID = 0;
 var BROADCAST_ID = 255;
 var NODE_SELF_SENSOR_ID = 255;
 
-var gateway = new Gateway;
-
-module.exports = gateway;
-
 
 function Gateway() {
 	eventEmitter.call(this);
@@ -373,4 +369,5 @@ Gateway.prototype._getNewNodeId = function () {
 	debugErr('Can`t register new node. There are no available id.');
 };
 
+module.exports = new Gateway;
 


### PR DESCRIPTION
I'm not sure why, but exporting the module at the end fixed the
following error in gateway-io.js:13:

"TypeError: gateway.on is not a function"
